### PR TITLE
backend route created to update inventory post-checkout

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const path = require('path');
 const morgan = require('morgan');
-
+const { fulfillStripeOrder } = require('./fulfillStripeOrder');
 //cors is for Stripe
 const cors = require('cors');
 require('dotenv').config();
@@ -11,6 +11,9 @@ const app = express();
 //for STRIPE
 const stripe = require('stripe')(process.env.REACT_APP_STRIPE_TEST_SECRET_KEY);
 const { v4: uuidv4 } = require('uuid');
+// Use body-parser to retrieve the raw body as a buffer
+const bodyParser = require('body-parser');
+const endpointSecret = process.env.STRIPE_WEBHOOK_KEY;
 
 //This is an attempt to get the redirects to play nice with Stripe on Heroku. We will see...
 let BASE_URL;
@@ -19,25 +22,172 @@ if (process.env.BASE_URL) {
 } else {
   BASE_URL = 'https://rugrats-grace-shopper.herokuapp.com';
 }
-console.log(BASE_URL);
 
 //MORGAN MIDDLEWARE
 app.use(morgan('dev'));
 
 //BODY PARSING MIDDLEWARE
-app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 //STATIC MIDDLEWARE
 app.use(express.static(path.join(__dirname, '..', 'public')));
 
-//PROJECT ROUTES
-app.use('/api', require('./api'));
-
 //STRIPE ROUTES
+//stripe route for order fulfillment
+app.post(
+  '/webhook',
+  bodyParser.raw({ type: 'application/json' }),
+  (request, response) => {
+    const payload = request.body;
+    const sig = request.headers['stripe-signature'];
+
+    let event;
+
+    try {
+      event = stripe.webhooks.constructEvent(payload, sig, endpointSecret);
+    } catch (err) {
+      return response.status(400).send(`Webhook Error: ${err.message}`);
+    }
+
+    // Handle the checkout.session.completed event
+    if (event.type === 'checkout.session.completed') {
+      const session = event.data.object;
+
+      //grab the line items!
+      stripe.checkout.sessions.listLineItems(
+        session.id,
+        { limit: 100, expand: ['data.price', 'data.price.product'] },
+        function (err, lineItems) {
+          // Fulfill the purchase...
+          try {
+            fulfillStripeOrder(session, lineItems);
+          } catch (err) {
+            return response
+              .status(400)
+              .send(`Fulfillment Error: ${err.message}`);
+          }
+        }
+      );
+    }
+
+    response.status(200);
+  }
+);
+
+//BODY PARSING MIDDLEWARE. Note that this middleware has to be implemented AFTER the stripe webhooks route!
+app.use(express.json());
+
+//Stripe checkout route
 app.post('/create-checkout-session', async (req, res) => {
   try {
     const session = await stripe.checkout.sessions.create({
+      shipping_address_collection: {
+        allowed_countries: [
+          'US',
+          'AE',
+          'AM',
+          'AR',
+          'AT',
+          'AU',
+          'BA',
+          'BE',
+          'BG',
+          'BO',
+          'CA',
+          'CH',
+          'CI',
+          'CL',
+          'CO',
+          'CR',
+          'CY',
+          'CZ',
+          'DE',
+          'DK',
+          'DO',
+          'EE',
+          'EG',
+          'ES',
+          'FI',
+          'FR',
+          'GB',
+          'GM',
+          'GR',
+          'HK',
+          'HR',
+          'HU',
+          'ID',
+          'IE',
+          'IL',
+          'IS',
+          'IT',
+          'JP',
+          'KE',
+          'KR',
+          'LI',
+          'LT',
+          'LU',
+          'LV',
+          'MA',
+          'MT',
+          'MU',
+          'MX',
+          'MY',
+          'NA',
+          'NL',
+          'NO',
+          'NZ',
+          'PA',
+          'PE',
+          'PH',
+          'PL',
+          'PT',
+          'PY',
+          'RO',
+          'RS',
+          'SA',
+          'SE',
+          'SG',
+          'SI',
+          'SK',
+          'SN',
+          'SV',
+          'TH',
+          'TN',
+          'TR',
+          'TT',
+          'UY',
+          'ZA',
+          'BD',
+          'BJ',
+          'JM',
+          'MC',
+          'NE',
+          'AG',
+          'BH',
+          'GH',
+          'GT',
+          'GY',
+          'KW',
+          'LC',
+          'SM',
+          'OM',
+          'AZ',
+          'BN',
+          'BT',
+          'EC',
+          'MD',
+          'MK',
+          'QA',
+          'AL',
+          'AO',
+          'DZ',
+          'JO',
+          'KH',
+          'MO',
+          'TZ',
+          'VN',
+        ],
+      },
       shipping_options: [
         {
           shipping_rate_data: {
@@ -64,8 +214,9 @@ app.post('/create-checkout-session', async (req, res) => {
       line_items: req.body.items,
       customer_email: req.body.email,
       mode: 'payment',
+      metadata: req.body.metadata,
       success_url: `${BASE_URL}/paymentSuccess`,
-      cancel_url: `${BASE_URL}/paymentCancel`,
+      cancel_url: `${BASE_URL}/checkout`,
     });
 
     res.json({ url: session.url });
@@ -73,6 +224,9 @@ app.post('/create-checkout-session', async (req, res) => {
     res.status(500).json({ error: e.message });
   }
 });
+
+//PROJECT ROUTES
+app.use('/api', require('./api'));
 
 //ANY UNDEFINED ROUTE GETS HANDLE WITH THIS
 app.get('*', (req, res, next) => {

--- a/server/fulfillStripeOrder.js
+++ b/server/fulfillStripeOrder.js
@@ -1,0 +1,20 @@
+const fulfillStripeOrder = (session, lineItems) => {
+  // TODO: fill me in
+
+  const { data: items } = lineItems;
+  const { GSR_order_id: order_id } = session.metadata;
+
+  for (let i = 0; i < items.length; i++) {
+    console.log(
+      'product: ',
+      session.metadata[i],
+      ' remove qty: ',
+      items[i].quantity
+    );
+  }
+
+  console.log('set order id: ', order_id, 'to fulfilled');
+};
+module.exports = {
+  fulfillStripeOrder,
+};

--- a/src/components/checkout/Checkout.jsx
+++ b/src/components/checkout/Checkout.jsx
@@ -44,17 +44,18 @@ export default function Checkout() {
 
   //go to stripe checkout
   const submitCheckout = () => {
+    //we map through the line items to create stripe-ready objects for each product
     const checkoutItems = lineItems.map((item) => {
       return {
-        adjustable_quantity: {
-          enabled: true,
-          minimum: 1,
-          maximum: item.product.stock,
-        },
+        // adjustable_quantity: {
+        //   enabled: true,
+        //   minimum: 1,
+        //   maximum: item.product.stock,
+        // },
         price_data: {
           currency: 'usd',
           product_data: {
-            name: item.product.artist.name + ' ' + item.product.name,
+            name: item.product.artist.name + ' - ' + item.product.name,
             description: 'Vinyl LP',
             images: [item.product.img],
           },
@@ -64,6 +65,15 @@ export default function Checkout() {
       };
     });
 
+    //because of how stripe works, we need to pass along our internal product ids
+    // so that we can adjust the inventory on the backend. We pass it through
+    // with the metadata field. There SHOULD be metadata fields on the line items
+    // objects, but I can't get access to them on the backend! Stripe fail.
+    const getProductIds = lineItems.map((item, index) => {
+      return `${item.product.id}`;
+    });
+
+    //now that the objects are created, we send them to our stripe route on the backend
     fetch('/create-checkout-session', {
       method: 'POST',
       headers: {
@@ -73,6 +83,7 @@ export default function Checkout() {
       body: JSON.stringify({
         items: checkoutItems,
         email: userData.username !== null ? userData.email : null,
+        metadata: { GSR_order_id: activeOrder.id, ...getProductIds },
       }),
     })
       .then((res) => {


### PR DESCRIPTION
body-parser was required for stripe route. Please `npm i`

This new route allows us to parse the Stripe checkout results so we can adjust our local state.
Logic will occur in `fulfillStripeOrder.js` in the `server` folder.

TODO:

In `fulfillStripeOrder.js`, we need to thunk some actions:

- remove purchased record quantity from inventory
- change user's order to fulfilled in the db and remove it from the redux cart


